### PR TITLE
use production flag in npm install

### DIFF
--- a/.github/workflows/luau.yml
+++ b/.github/workflows/luau.yml
@@ -17,7 +17,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install node_modules
         run: |
-          npm install -g roblox-ts@latest
+          npm install -g --production roblox-ts@latest
           npm install
           
       - name: Configure Git


### PR DESCRIPTION
This flag skips out on installing dev dependencies, like the types.