### PR TITLE
Fix InferClientRemote for BidirectionalEvent

### DIFF
--- a/src/definitions/Types.ts
+++ b/src/definitions/Types.ts
@@ -223,7 +223,7 @@ export type InferClientRemote<T> = T extends AsyncClientFunctionDeclaration<infe
 	: T extends ServerToClientEventDeclaration<infer A>
 	? ClientListenerEvent<A>
 	: T extends BidirectionalEventDeclaration<infer S, infer C>
-	? ClientEvent<S, C>
+	? ClientEvent<C, S>
 	: T extends LegacyEventDeclaration<infer SA, infer CA>
 	? ClientEvent<CA, SA>
 	: T extends LegacyAsyncFunctionDeclaration<infer SA, infer SR, infer CA, infer CR>


### PR DESCRIPTION
Currently, the a client bidirectional event is receiving the arguments in the wrong order when created in Definitions.

A `ClientEvent` accepts the following arguments:
```ts
ClientEvent<ConnectArgs extends any = any, CallArguments extends any = any>
```
When a BidirectionalEvent is made, it is made with the one of the following constructors:
```ts
function BidirectionalEvent<ServerConnect extends readonly unknown[] = unknown[], ClientConnect extends readonly unknown[] = unknown[]>(): BidirectionalEventDeclaration<ServerConnect, ClientConnect>;

function BidirectionalEvent<ServerConnect extends readonly unknown[] = unknown[], ClientConnect extends readonly unknown[] = unknown[]>(mw?: MiddlewareOverload<ServerConnect>): BidirectionalEventDeclaration<ServerConnect, ClientConnect>;
```

Inside InferClientRemote, currently the definition is
```ts
T extends BidirectionalEventDeclaration<infer S, infer C> ? ClientEvent<S, C>
```
This is incorrect, because we are passing the `ServerConnect` arguments in to the client `ConnectArgs`. It should be the other way around, where `ConnectArgs` accepts the `ClientConnect` arguments.

This pull request swaps the order around for the `InferClientRemote` type so that it is correct.