### PR TITLE
Fix RemoteEvents not disconnecting on server

### DIFF
--- a/src/server/NetServerScriptSignal.ts
+++ b/src/server/NetServerScriptSignal.ts
@@ -50,7 +50,7 @@ export class NetServerScriptSignal<
 			RBXSignal: connection,
 			Connected: connection.Connected,
 			Disconnect() {
-				const idx = this.NetSignal.connections.findIndex((f) => f === ref);
+				const idx = this.NetSignal.connections.findIndex((f) => f === connection);
 				if (idx !== -1) {
 					this.NetSignal.DisconnectAt(idx);
 					this.Connected = false;


### PR DESCRIPTION
It seems like RemoteEvents don't get disconnected on the server when calling the `Disconnect()` method, creating undesired behavior.